### PR TITLE
feat(lunr): indexing the names of the variants - noissue

### DIFF
--- a/packages/ecl-fractal-theme/src/search.js
+++ b/packages/ecl-fractal-theme/src/search.js
@@ -2,10 +2,6 @@ const fs = require('fs');
 const lunr = require('lunr');
 
 module.exports = (theme, env, app) => {
-  const getVariants = variants => {
-    variants.map(variant => variant.label);
-  };
-
   const store = {};
 
   const lunarIndex = lunr(function buildSchema() {

--- a/packages/ecl-fractal-theme/src/search.js
+++ b/packages/ecl-fractal-theme/src/search.js
@@ -2,6 +2,10 @@ const fs = require('fs');
 const lunr = require('lunr');
 
 module.exports = (theme, env, app) => {
+  const getVariants = variants => {
+    variants.map(variant => variant.label);
+  };
+
   const store = {};
 
   const lunarIndex = lunr(function buildSchema() {
@@ -10,6 +14,7 @@ module.exports = (theme, env, app) => {
     this.field('name');
     this.field('handle');
     this.field('notes');
+    this.field('variants');
     this.pipeline.remove(lunr.stopWordFilter);
   });
 
@@ -22,6 +27,9 @@ module.exports = (theme, env, app) => {
       handle: c.handle,
       title: c.title,
       notes: c.notes ? `${c.notes.substring(0, 50)} ...` : '',
+      variants: c.variants.items.length
+        ? c.variants.items.map(v => v.name)
+        : '',
     }));
 
   // eslint-disable-next-line no-restricted-syntax

--- a/packages/ecl-fractal-theme/src/search.js
+++ b/packages/ecl-fractal-theme/src/search.js
@@ -23,7 +23,7 @@ module.exports = (theme, env, app) => {
       handle: c.handle,
       title: c.title,
       notes: c.notes ? `${c.notes.substring(0, 50)} ...` : '',
-      variants: c.variants.items.length
+      variants: c.variants && c.variants.items && c.variants.items.length
         ? c.variants.items.map(v => v.name)
         : '',
     }));

--- a/packages/ecl-fractal-theme/src/search.js
+++ b/packages/ecl-fractal-theme/src/search.js
@@ -1,3 +1,4 @@
+const get = require('lodash/get');
 const fs = require('fs');
 const lunr = require('lunr');
 
@@ -23,9 +24,7 @@ module.exports = (theme, env, app) => {
       handle: c.handle,
       title: c.title,
       notes: c.notes ? `${c.notes.substring(0, 50)} ...` : '',
-      variants: c.variants && c.variants.items && c.variants.items.length
-        ? c.variants.items.map(v => v.name)
-        : '',
+      variants: get(c, 'variants.items', []).map(v => v.name),
     }));
 
   // eslint-disable-next-line no-restricted-syntax


### PR DESCRIPTION
It's a very small modification which is adding the names of the variants in the index. Still, the main component is visible in the results and is shown when clicked in the results.

An example in the basic theme is the `internal` variant of the search forms.